### PR TITLE
Fixed transient issue when saving level

### DIFF
--- a/Source/ZipUtility/Private/ZipFileFunctionInternaCallback.cpp
+++ b/Source/ZipUtility/Private/ZipFileFunctionInternaCallback.cpp
@@ -3,7 +3,11 @@
 
 UZipFileFunctionInternalCallback::UZipFileFunctionInternalCallback()
 {
-
+	CompressionFormat = ZipUtilityCompressionFormat::COMPRESSION_FORMAT_UNKNOWN;
+	DestinationFolder = FString();
+	File = FString();
+	FileIndex = 0;
+	Callback = NULL;
 }
 
 void UZipFileFunctionInternalCallback::OnFileFound_Implementation(const FString& archive, const FString& fileIn, int32 size)

--- a/Source/ZipUtility/Private/ZipFileFunctionInternalCallback.h
+++ b/Source/ZipUtility/Private/ZipFileFunctionInternalCallback.h
@@ -11,23 +11,32 @@ class ZIPUTILITY_API UZipFileFunctionInternalCallback : public UObject, public I
 private:
 
 	/** Compression format used to unzip */
+	UPROPERTY(Transient)
 	TEnumAsByte<ZipUtilityCompressionFormat> CompressionFormat;
 
 	/** Path of the file */
+	UPROPERTY(Transient)
 	FString File;
 
+	UPROPERTY(Transient)
 	FString DestinationFolder;
 
 	/** Current File index parsed */
+	UPROPERTY(Transient)
 	int32 FileIndex = 0;
 
 	/** Callback object */
 	UPROPERTY(Transient)
 	UObject* Callback;
 
-	bool bSingleFile = false;
-	bool bFileFound = false;
-	bool bUnzipto = false;
+	UPROPERTY(Transient)
+	bool bSingleFile;
+
+	UPROPERTY(Transient)
+	bool bFileFound;
+
+	UPROPERTY(Transient)
+	bool bUnzipto;
 
 public:
 	UZipFileFunctionInternalCallback();

--- a/Source/ZipUtility/Public/ZipFileFunctionLibrary.h
+++ b/Source/ZipUtility/Public/ZipFileFunctionLibrary.h
@@ -27,6 +27,9 @@ class ZIPUTILITY_API UZipFileFunctionLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_UCLASS_BODY()
 
+private:
+	static UZipFileFunctionInternalCallback* InternalCallback;
+
 public:
 	~UZipFileFunctionLibrary();
 	


### PR DESCRIPTION
There was an issue with the internal callback messing up the object graph. 
